### PR TITLE
Removing second namespace declaration

### DIFF
--- a/lib/Doctrine/DBAL/Types/EnumType.php
+++ b/lib/Doctrine/DBAL/Types/EnumType.php
@@ -2,8 +2,6 @@
 
 namespace Shmaltorhbooks\Doctrine\DBAL\Types;
 
-namespace Hub\BaseBundle\DependencyInjection\Doctrine\Extensions\DBAL;
-
 use Doctrine\DBAL\Platforms\AbstractPlatform,
     Doctrine\DBAL\Types\Type;
 


### PR DESCRIPTION
The second namespace declaration looked like it belonged in another project and since the examples listed the first namespace to use in the config I removed the second one.