### PR TITLE
Fixing autoload settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "Shmaltorhbooks": "lib/"
+            "Shmaltorhbooks\\": "lib/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "Shmaltorhbooks": "lib/"
         }
     },


### PR DESCRIPTION
Your project folder structure, namespacing and class naming conventions indicate the use of PSR-4 but PSR-0 is specified in the autoload options of composer.json.

Because of the PSR-0 setting the autoloader logic tries (and fails) to load `vendor/shmaltorhbooks/doctrine-enum/lib/Shmaltorhbooks/Doctrine/DBAL/Types/EnumType.php`.

Setting the autoloader to PSR-4 fixes this issue directly (as you currently have the correct directory structure for PSR-4). Alternatively you can change the folder structure.